### PR TITLE
 Bump `sizeup-core` to `0.3.1`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This section contains notes for how to develop this library.
 
 ### Building the distributed code for this Action
 
-As is common for Actions, this repository contains the distributed code for this Action in the [`dist`](./dist/) directory. As a result, any change to a file in [`src`](./src/) must also be accompanied by manual compilation. This should be done with the following command:
+As is common for Actions, this repository contains the distributed code for this Action in the [`dist`](./dist/) directory. As a result, any change to a file in [`src`](./src/) or to [`package.json`](./package.json) must also be accompanied by manual compilation. This should be done with the following command:
 
 ```sh
 npm run all

--- a/dist/index.js
+++ b/dist/index.js
@@ -6827,7 +6827,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const feature_1 = __nccwpck_require__(7184);
 class Tests extends feature_1.default {
     evaluate() {
-        return this.changeset.files.reduce((sum, f) => sum + (f.isTestFile ? f.additions : 0), 0);
+        return this.changeset.files.reduce((sum, f) => sum + (f.isTestFile ? f.additions + f.deletions : 0), 0);
     }
 }
 exports["default"] = Tests;
@@ -7148,13 +7148,17 @@ class SizeUp {
      */
     static evaluate(diff, configPath) {
         var _a;
-        const config = configPath ? YAML.parse(fs.readFileSync(configPath, "utf8")) : {};
+        let userSuppliedConfig = {};
+        if (configPath) {
+            const parsed = YAML.parse(fs.readFileSync(configPath, "utf8"));
+            userSuppliedConfig = ('sizeup' in parsed) ? parsed.sizeup : parsed;
+        }
         const defaultConfig = YAML.parse(fs.readFileSync(__nccwpck_require__.ab + "default.yaml", "utf8"));
-        const ignoredFilePatterns = config.ignoredFilePatterns || defaultConfig.ignoredFilePatterns;
-        const testFilePatterns = config.testFilePatterns || defaultConfig.testFilePatterns;
+        const ignoredFilePatterns = userSuppliedConfig.ignoredFilePatterns || defaultConfig.ignoredFilePatterns;
+        const testFilePatterns = userSuppliedConfig.testFilePatterns || defaultConfig.testFilePatterns;
         const changeset = new changeset_1.default({ diff, ignoredFilePatterns, testFilePatterns });
-        const categories = new category_configuration_1.CategoryConfiguration(config.categories || defaultConfig.categories);
-        const formula = new formula_1.Formula(((_a = config.scoring) === null || _a === void 0 ? void 0 : _a.formula) || defaultConfig.scoring.formula);
+        const categories = new category_configuration_1.CategoryConfiguration(userSuppliedConfig.categories || defaultConfig.categories);
+        const formula = new formula_1.Formula(((_a = userSuppliedConfig.scoring) === null || _a === void 0 ? void 0 : _a.formula) || defaultConfig.scoring.formula);
         return formula.evaluate(changeset, categories);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.1",
         "@actions/github": "^5.1.1",
         "@octokit/webhooks": "^12.0.3",
-        "sizeup-core": "^0.2.0",
+        "sizeup-core": "^0.3.0",
         "yaml": "^2.3.2"
       },
       "devDependencies": {
@@ -6692,9 +6692,9 @@
       "dev": true
     },
     "node_modules/sizeup-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.2.1.tgz",
-      "integrity": "sha512-cZAggc3tA1nNrQc72RKJ98nJBPlatXMmFDLhJfTPP91mjefhMkrA+9X96pvzLiApLzbtosLa7NQdsraofi0zBQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.3.1.tgz",
+      "integrity": "sha512-W1fQ7m2DD5Fy+i//WPvtwMwZLEhPO40MqRLljf+wwsKr7c5X3r+v7JskufefrBpJR50F7/jZBlFfCmPOsyWYJg==",
       "dependencies": {
         "minimatch": "^9.0.3",
         "parse-diff": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@actions/core": "^1.10.1",
     "@actions/github": "^5.1.1",
     "@octokit/webhooks": "^12.0.3",
-    "sizeup-core": "^0.2.0",
+    "sizeup-core": "^0.3.0",
     "yaml": "^2.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This pulls in a fix that ensures that both additions and deletions are counted by the `tests` evaluation feature (as opposed to only additions).