### PR TITLE
Bump sizeup-core to 0.3.4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12427,7 +12427,7 @@ exports.Formula = Formula;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.SUPPORTED_LANGUAGES = exports.YAML = exports.XML = exports.TypeScript = exports.Swift = exports.Rust = exports.Ruby = exports.Python = exports.Kotlin = exports.JavaScript = exports.Java = exports.HTML = exports.Go = exports.CSharp = exports.CommentStyleFamily = exports.Linguist = void 0;
+exports.SUPPORTED_LANGUAGES = exports.YAML = exports.XML = exports.TypeScript = exports.Swift = exports.StringsDict = exports.Strings = exports.Rust = exports.Ruby = exports.Python = exports.Kotlin = exports.JavaScript = exports.Java = exports.HTML = exports.Go = exports.CSharp = exports.CommentStyleFamily = exports.Linguist = void 0;
 /** A utility class for language-specific behaviour. */
 class Linguist {
     /** Tries to match the given filename to a supported language based on its file extension. */
@@ -12501,6 +12501,16 @@ exports.Rust = {
     fileExtensions: ["rs"],
     ...cStyleComments,
 };
+exports.Strings = {
+    name: "Strings",
+    fileExtensions: ["strings"],
+    ...cStyleComments,
+};
+exports.StringsDict = {
+    name: "StringsDict",
+    fileExtensions: ["stringsdict"],
+    ...htmlStyleComments,
+};
 exports.Swift = {
     name: "Swift",
     fileExtensions: ["swift"],
@@ -12531,6 +12541,8 @@ exports.SUPPORTED_LANGUAGES = [
     exports.Python,
     exports.Ruby,
     exports.Rust,
+    exports.Strings,
+    exports.StringsDict,
     exports.Swift,
     exports.TypeScript,
     exports.XML,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6718,9 +6718,9 @@
       "dev": true
     },
     "node_modules/sizeup-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.3.3.tgz",
-      "integrity": "sha512-nWRYrbA9scSNz6gr+K2cRasRVZdORAg9Nr78MLwVBa5Esi1b27lRcIJRT4eRIe4v4gLOGX7WJQNeRRLfINftQg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.3.4.tgz",
+      "integrity": "sha512-1uU0aF65z+XkECTLt0gWa7lOaMXB96FL11R4/GHYS4kh/3usXhovGbfTXbIVw/bX8egEwkV3jVqSPxn1VIoI7Q==",
       "dependencies": {
         "minimatch": "^9.0.3",
         "parse-diff": "^0.11.1",


### PR DESCRIPTION
This adds support for comment recognition in  Apple localization files (`.strings` and `.stringsdict`).