### PR TITLE
Correct value of `--shallow-since` flag used to fetch history from base branch.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16400,7 +16400,7 @@ async function fetchDiff(pull) {
     const divergedFrom = await git.raw('rev-list', '--max-parents=0', 'HEAD');
     const divergedAt = await git.show([
         '--quiet',
-        '--date=iso8601',
+        '--date=unix',
         '--format=%cd',
         divergedFrom
     ]);

--- a/src/initializer.ts
+++ b/src/initializer.ts
@@ -59,7 +59,7 @@ export async function fetchDiff(pull: PullRequest): Promise<string> {
   const divergedFrom = await git.raw('rev-list', '--max-parents=0', 'HEAD')
   const divergedAt = await git.show([
     '--quiet',
-    '--date=iso8601',
+    '--date=unix',
     '--format=%cd',
     divergedFrom
   ])


### PR DESCRIPTION
This should ensure that we actually fetch the requisite amount of history necessary to find a merge base. Previously, the value of the flag contained a space, which appeared to cause incorrect behaviour.

This should hopefully address #31.