### PR TITLE
Update recommended workflow triggers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ All aspects of this Action are [configurable](#configuration), including how siz
 ```yaml
 name: SizeUp
 
-on: pull_request
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
 
 permissions:
   contents: read


### PR DESCRIPTION
Augment the default set of pull request trigger types (`opened`, `synchronize`, and `reopened`) with two more that are useful with this workflow:

- `edited`, which allows this workflow to recompute the reviewability score after the base branch of the pull request changes (e.g. if the pull request that it was stacked on top of was merged)
- `ready_for_review`, which gives the workflow a fresh chance to post a score threshold exceeded comment on a pull request if the workflow was configured to suppress those comments on drafts