### PR TITLE
Allow opt in logins to be case insensitive

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -267,6 +267,24 @@ describe('action', () => {
     expect(setOutputMock).toHaveBeenNthCalledWith(2, 'category', 'extra small')
   })
 
+  it('runs the workflow sucessfully regardless of casing of optIns and pull request author login', async () => {
+    // Mock the @actions/github context.
+    Object.defineProperty(github, 'context', {
+      value: pullRequestEventContext({ user: { login: 'LeReBeAr' } })
+    })
+
+    loadConfigurationMock.mockImplementation(() => ({
+      optIns: ['lerebear']
+    }))
+
+    await main.run()
+
+    expect(runMock).toHaveReturned()
+    expect(setFailedMock).not.toHaveBeenCalled()
+    expect(setOutputMock).toHaveBeenNthCalledWith(1, 'score', 1)
+    expect(setOutputMock).toHaveBeenNthCalledWith(2, 'category', 'extra small')
+  })
+
   it('skips the workflow entirely when the pull request author has not opted into it', async () => {
     // Mock the @actions/github context.
     Object.defineProperty(github, 'context', {

--- a/src/initializer.ts
+++ b/src/initializer.ts
@@ -43,7 +43,9 @@ export function getOptInStatus(
   const usersWhoHaveOptedin = config.optIns || []
   const userHasOptedOut =
     usersWhoHaveOptedin.length &&
-    !usersWhoHaveOptedin.find((login: string) => login === pull.user.login)
+    !usersWhoHaveOptedin.find(
+      (login: string) => login.toLowerCase() === pull.user.login.toLowerCase()
+    )
 
   if (userHasOptedOut && config.shadowOptOuts) {
     core.info('Executing workflow silently for user who was not opted in')


### PR DESCRIPTION
Resolves https://github.com/lerebear/sizeup-action/issues/51

This PR updates the comparison between the logins in the optIns config and the PR author to be case insensitive. Also hopefully adds the right kind of test for this.